### PR TITLE
Generate watcher with DB caching for multiple return type

### DIFF
--- a/packages/azimuth-watcher/src/database.ts
+++ b/packages/azimuth-watcher/src/database.ts
@@ -433,9 +433,9 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
-  async saveGetKeys ({ blockHash, blockNumber, contractAddress, _point, value, proof }: DeepPartial<GetKeys>): Promise<GetKeys> {
+  async saveGetKeys ({ blockHash, blockNumber, contractAddress, _point, value0, value1, value2, value3, proof }: DeepPartial<GetKeys>): Promise<GetKeys> {
     const repo = this._conn.getRepository(GetKeys);
-    const entity = repo.create({ blockHash, blockNumber, contractAddress, _point, value, proof });
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _point, value0, value1, value2, value3, proof });
     return repo.save(entity);
   }
 

--- a/packages/azimuth-watcher/src/entity/GetKeys.ts
+++ b/packages/azimuth-watcher/src/entity/GetKeys.ts
@@ -24,7 +24,16 @@ export class GetKeys {
     _point!: bigint;
 
   @Column('varchar')
-    value!: string;
+    value0!: string;
+
+  @Column('varchar')
+    value1!: string;
+
+  @Column('numeric', { transformer: bigintTransformer })
+    value2!: bigint;
+
+  @Column('numeric', { transformer: bigintTransformer })
+    value3!: bigint;
 
   @Column('text', { nullable: true })
     proof!: string;


### PR DESCRIPTION
Part of cerc-io/watcher-ts#351

- Generate watcher with support for DB caching of multiple return types