### PR TITLE
Generate watchers with DB caching for array return types

### DIFF
--- a/packages/azimuth-watcher/src/client.ts
+++ b/packages/azimuth-watcher/src/client.ts
@@ -80,6 +80,15 @@ export class Client {
     return getSpawnCount;
   }
 
+  async getGetSpawned (blockHash: string, contractAddress: string, _point: bigint): Promise<any> {
+    const { getSpawned } = await this._client.query(
+      gql(queries.getSpawned),
+      { blockHash, contractAddress, _point }
+    );
+
+    return getSpawned;
+  }
+
   async getHasSponsor (blockHash: string, contractAddress: string, _point: bigint): Promise<any> {
     const { hasSponsor } = await this._client.query(
       gql(queries.hasSponsor),
@@ -114,6 +123,15 @@ export class Client {
     );
 
     return getSponsoringCount;
+  }
+
+  async getGetSponsoring (blockHash: string, contractAddress: string, _sponsor: bigint): Promise<any> {
+    const { getSponsoring } = await this._client.query(
+      gql(queries.getSponsoring),
+      { blockHash, contractAddress, _sponsor }
+    );
+
+    return getSponsoring;
   }
 
   async getIsEscaping (blockHash: string, contractAddress: string, _point: bigint): Promise<any> {
@@ -152,6 +170,15 @@ export class Client {
     return getEscapeRequestsCount;
   }
 
+  async getGetEscapeRequests (blockHash: string, contractAddress: string, _sponsor: bigint): Promise<any> {
+    const { getEscapeRequests } = await this._client.query(
+      gql(queries.getEscapeRequests),
+      { blockHash, contractAddress, _sponsor }
+    );
+
+    return getEscapeRequests;
+  }
+
   async getGetOwner (blockHash: string, contractAddress: string, _point: bigint): Promise<any> {
     const { getOwner } = await this._client.query(
       gql(queries.getOwner),
@@ -177,6 +204,15 @@ export class Client {
     );
 
     return getOwnedPointCount;
+  }
+
+  async getGetOwnedPoints (blockHash: string, contractAddress: string, _whose: string): Promise<any> {
+    const { getOwnedPoints } = await this._client.query(
+      gql(queries.getOwnedPoints),
+      { blockHash, contractAddress, _whose }
+    );
+
+    return getOwnedPoints;
   }
 
   async getGetOwnedPointAtIndex (blockHash: string, contractAddress: string, _whose: string, _index: bigint): Promise<any> {
@@ -224,6 +260,15 @@ export class Client {
     return getManagerForCount;
   }
 
+  async getGetManagerFor (blockHash: string, contractAddress: string, _proxy: string): Promise<any> {
+    const { getManagerFor } = await this._client.query(
+      gql(queries.getManagerFor),
+      { blockHash, contractAddress, _proxy }
+    );
+
+    return getManagerFor;
+  }
+
   async getGetSpawnProxy (blockHash: string, contractAddress: string, _point: bigint): Promise<any> {
     const { getSpawnProxy } = await this._client.query(
       gql(queries.getSpawnProxy),
@@ -258,6 +303,15 @@ export class Client {
     );
 
     return getSpawningForCount;
+  }
+
+  async getGetSpawningFor (blockHash: string, contractAddress: string, _proxy: string): Promise<any> {
+    const { getSpawningFor } = await this._client.query(
+      gql(queries.getSpawningFor),
+      { blockHash, contractAddress, _proxy }
+    );
+
+    return getSpawningFor;
   }
 
   async getGetVotingProxy (blockHash: string, contractAddress: string, _point: bigint): Promise<any> {
@@ -296,6 +350,15 @@ export class Client {
     return getVotingForCount;
   }
 
+  async getGetVotingFor (blockHash: string, contractAddress: string, _proxy: string): Promise<any> {
+    const { getVotingFor } = await this._client.query(
+      gql(queries.getVotingFor),
+      { blockHash, contractAddress, _proxy }
+    );
+
+    return getVotingFor;
+  }
+
   async getGetTransferProxy (blockHash: string, contractAddress: string, _point: bigint): Promise<any> {
     const { getTransferProxy } = await this._client.query(
       gql(queries.getTransferProxy),
@@ -330,6 +393,15 @@ export class Client {
     );
 
     return getTransferringForCount;
+  }
+
+  async getGetTransferringFor (blockHash: string, contractAddress: string, _proxy: string): Promise<any> {
+    const { getTransferringFor } = await this._client.query(
+      gql(queries.getTransferringFor),
+      { blockHash, contractAddress, _proxy }
+    );
+
+    return getTransferringFor;
   }
 
   async getIsOperator (blockHash: string, contractAddress: string, _owner: string, _operator: string): Promise<any> {

--- a/packages/azimuth-watcher/src/database.ts
+++ b/packages/azimuth-watcher/src/database.ts
@@ -27,37 +27,45 @@ import { HasBeenLinked } from './entity/HasBeenLinked';
 import { IsLive } from './entity/IsLive';
 import { GetContinuityNumber } from './entity/GetContinuityNumber';
 import { GetSpawnCount } from './entity/GetSpawnCount';
+import { GetSpawned } from './entity/GetSpawned';
 import { HasSponsor } from './entity/HasSponsor';
 import { GetSponsor } from './entity/GetSponsor';
 import { IsSponsor } from './entity/IsSponsor';
 import { GetSponsoringCount } from './entity/GetSponsoringCount';
+import { GetSponsoring } from './entity/GetSponsoring';
 import { IsEscaping } from './entity/IsEscaping';
 import { GetEscapeRequest } from './entity/GetEscapeRequest';
 import { IsRequestingEscapeTo } from './entity/IsRequestingEscapeTo';
 import { GetEscapeRequestsCount } from './entity/GetEscapeRequestsCount';
+import { GetEscapeRequests } from './entity/GetEscapeRequests';
 import { GetOwner } from './entity/GetOwner';
 import { IsOwner } from './entity/IsOwner';
 import { GetOwnedPointCount } from './entity/GetOwnedPointCount';
+import { GetOwnedPoints } from './entity/GetOwnedPoints';
 import { GetOwnedPointAtIndex } from './entity/GetOwnedPointAtIndex';
 import { GetManagementProxy } from './entity/GetManagementProxy';
 import { IsManagementProxy } from './entity/IsManagementProxy';
 import { CanManage } from './entity/CanManage';
 import { GetManagerForCount } from './entity/GetManagerForCount';
+import { GetManagerFor } from './entity/GetManagerFor';
 import { GetSpawnProxy } from './entity/GetSpawnProxy';
 import { IsSpawnProxy } from './entity/IsSpawnProxy';
 import { CanSpawnAs } from './entity/CanSpawnAs';
 import { GetSpawningForCount } from './entity/GetSpawningForCount';
+import { GetSpawningFor } from './entity/GetSpawningFor';
 import { GetVotingProxy } from './entity/GetVotingProxy';
 import { IsVotingProxy } from './entity/IsVotingProxy';
 import { CanVoteAs } from './entity/CanVoteAs';
 import { GetVotingForCount } from './entity/GetVotingForCount';
+import { GetVotingFor } from './entity/GetVotingFor';
 import { GetTransferProxy } from './entity/GetTransferProxy';
 import { IsTransferProxy } from './entity/IsTransferProxy';
 import { CanTransfer } from './entity/CanTransfer';
 import { GetTransferringForCount } from './entity/GetTransferringForCount';
+import { GetTransferringFor } from './entity/GetTransferringFor';
 import { IsOperator } from './entity/IsOperator';
 
-export const ENTITIES = [IsActive, GetKeys, GetKeyRevisionNumber, HasBeenLinked, IsLive, GetContinuityNumber, GetSpawnCount, HasSponsor, GetSponsor, IsSponsor, GetSponsoringCount, IsEscaping, GetEscapeRequest, IsRequestingEscapeTo, GetEscapeRequestsCount, GetOwner, IsOwner, GetOwnedPointCount, GetOwnedPointAtIndex, GetManagementProxy, IsManagementProxy, CanManage, GetManagerForCount, GetSpawnProxy, IsSpawnProxy, CanSpawnAs, GetSpawningForCount, GetVotingProxy, IsVotingProxy, CanVoteAs, GetVotingForCount, GetTransferProxy, IsTransferProxy, CanTransfer, GetTransferringForCount, IsOperator];
+export const ENTITIES = [IsActive, GetKeys, GetKeyRevisionNumber, HasBeenLinked, IsLive, GetContinuityNumber, GetSpawnCount, GetSpawned, HasSponsor, GetSponsor, IsSponsor, GetSponsoringCount, GetSponsoring, IsEscaping, GetEscapeRequest, IsRequestingEscapeTo, GetEscapeRequestsCount, GetEscapeRequests, GetOwner, IsOwner, GetOwnedPointCount, GetOwnedPoints, GetOwnedPointAtIndex, GetManagementProxy, IsManagementProxy, CanManage, GetManagerForCount, GetManagerFor, GetSpawnProxy, IsSpawnProxy, CanSpawnAs, GetSpawningForCount, GetSpawningFor, GetVotingProxy, IsVotingProxy, CanVoteAs, GetVotingForCount, GetVotingFor, GetTransferProxy, IsTransferProxy, CanTransfer, GetTransferringForCount, GetTransferringFor, IsOperator];
 
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions;
@@ -153,6 +161,15 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetSpawned ({ blockHash, contractAddress, _point }: { blockHash: string, contractAddress: string, _point: bigint }): Promise<GetSpawned | undefined> {
+    return this._conn.getRepository(GetSpawned)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _point
+      });
+  }
+
   async getHasSponsor ({ blockHash, contractAddress, _point }: { blockHash: string, contractAddress: string, _point: bigint }): Promise<HasSponsor | undefined> {
     return this._conn.getRepository(HasSponsor)
       .findOne({
@@ -183,6 +200,15 @@ export class Database implements DatabaseInterface {
 
   async getGetSponsoringCount ({ blockHash, contractAddress, _sponsor }: { blockHash: string, contractAddress: string, _sponsor: bigint }): Promise<GetSponsoringCount | undefined> {
     return this._conn.getRepository(GetSponsoringCount)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _sponsor
+      });
+  }
+
+  async getGetSponsoring ({ blockHash, contractAddress, _sponsor }: { blockHash: string, contractAddress: string, _sponsor: bigint }): Promise<GetSponsoring | undefined> {
+    return this._conn.getRepository(GetSponsoring)
       .findOne({
         blockHash,
         contractAddress,
@@ -227,6 +253,15 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetEscapeRequests ({ blockHash, contractAddress, _sponsor }: { blockHash: string, contractAddress: string, _sponsor: bigint }): Promise<GetEscapeRequests | undefined> {
+    return this._conn.getRepository(GetEscapeRequests)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _sponsor
+      });
+  }
+
   async getGetOwner ({ blockHash, contractAddress, _point }: { blockHash: string, contractAddress: string, _point: bigint }): Promise<GetOwner | undefined> {
     return this._conn.getRepository(GetOwner)
       .findOne({
@@ -248,6 +283,15 @@ export class Database implements DatabaseInterface {
 
   async getGetOwnedPointCount ({ blockHash, contractAddress, _whose }: { blockHash: string, contractAddress: string, _whose: string }): Promise<GetOwnedPointCount | undefined> {
     return this._conn.getRepository(GetOwnedPointCount)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _whose
+      });
+  }
+
+  async getGetOwnedPoints ({ blockHash, contractAddress, _whose }: { blockHash: string, contractAddress: string, _whose: string }): Promise<GetOwnedPoints | undefined> {
+    return this._conn.getRepository(GetOwnedPoints)
       .findOne({
         blockHash,
         contractAddress,
@@ -303,6 +347,15 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetManagerFor ({ blockHash, contractAddress, _proxy }: { blockHash: string, contractAddress: string, _proxy: string }): Promise<GetManagerFor | undefined> {
+    return this._conn.getRepository(GetManagerFor)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _proxy
+      });
+  }
+
   async getGetSpawnProxy ({ blockHash, contractAddress, _point }: { blockHash: string, contractAddress: string, _point: bigint }): Promise<GetSpawnProxy | undefined> {
     return this._conn.getRepository(GetSpawnProxy)
       .findOne({
@@ -334,6 +387,15 @@ export class Database implements DatabaseInterface {
 
   async getGetSpawningForCount ({ blockHash, contractAddress, _proxy }: { blockHash: string, contractAddress: string, _proxy: string }): Promise<GetSpawningForCount | undefined> {
     return this._conn.getRepository(GetSpawningForCount)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _proxy
+      });
+  }
+
+  async getGetSpawningFor ({ blockHash, contractAddress, _proxy }: { blockHash: string, contractAddress: string, _proxy: string }): Promise<GetSpawningFor | undefined> {
+    return this._conn.getRepository(GetSpawningFor)
       .findOne({
         blockHash,
         contractAddress,
@@ -379,6 +441,15 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetVotingFor ({ blockHash, contractAddress, _proxy }: { blockHash: string, contractAddress: string, _proxy: string }): Promise<GetVotingFor | undefined> {
+    return this._conn.getRepository(GetVotingFor)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _proxy
+      });
+  }
+
   async getGetTransferProxy ({ blockHash, contractAddress, _point }: { blockHash: string, contractAddress: string, _point: bigint }): Promise<GetTransferProxy | undefined> {
     return this._conn.getRepository(GetTransferProxy)
       .findOne({
@@ -410,6 +481,15 @@ export class Database implements DatabaseInterface {
 
   async getGetTransferringForCount ({ blockHash, contractAddress, _proxy }: { blockHash: string, contractAddress: string, _proxy: string }): Promise<GetTransferringForCount | undefined> {
     return this._conn.getRepository(GetTransferringForCount)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _proxy
+      });
+  }
+
+  async getGetTransferringFor ({ blockHash, contractAddress, _proxy }: { blockHash: string, contractAddress: string, _proxy: string }): Promise<GetTransferringFor | undefined> {
+    return this._conn.getRepository(GetTransferringFor)
       .findOne({
         blockHash,
         contractAddress,
@@ -469,6 +549,12 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
+  async saveGetSpawned ({ blockHash, blockNumber, contractAddress, _point, value, proof }: DeepPartial<GetSpawned>): Promise<GetSpawned> {
+    const repo = this._conn.getRepository(GetSpawned);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _point, value, proof });
+    return repo.save(entity);
+  }
+
   async saveHasSponsor ({ blockHash, blockNumber, contractAddress, _point, value, proof }: DeepPartial<HasSponsor>): Promise<HasSponsor> {
     const repo = this._conn.getRepository(HasSponsor);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _point, value, proof });
@@ -489,6 +575,12 @@ export class Database implements DatabaseInterface {
 
   async saveGetSponsoringCount ({ blockHash, blockNumber, contractAddress, _sponsor, value, proof }: DeepPartial<GetSponsoringCount>): Promise<GetSponsoringCount> {
     const repo = this._conn.getRepository(GetSponsoringCount);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _sponsor, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetSponsoring ({ blockHash, blockNumber, contractAddress, _sponsor, value, proof }: DeepPartial<GetSponsoring>): Promise<GetSponsoring> {
+    const repo = this._conn.getRepository(GetSponsoring);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _sponsor, value, proof });
     return repo.save(entity);
   }
@@ -517,6 +609,12 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
+  async saveGetEscapeRequests ({ blockHash, blockNumber, contractAddress, _sponsor, value, proof }: DeepPartial<GetEscapeRequests>): Promise<GetEscapeRequests> {
+    const repo = this._conn.getRepository(GetEscapeRequests);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _sponsor, value, proof });
+    return repo.save(entity);
+  }
+
   async saveGetOwner ({ blockHash, blockNumber, contractAddress, _point, value, proof }: DeepPartial<GetOwner>): Promise<GetOwner> {
     const repo = this._conn.getRepository(GetOwner);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _point, value, proof });
@@ -531,6 +629,12 @@ export class Database implements DatabaseInterface {
 
   async saveGetOwnedPointCount ({ blockHash, blockNumber, contractAddress, _whose, value, proof }: DeepPartial<GetOwnedPointCount>): Promise<GetOwnedPointCount> {
     const repo = this._conn.getRepository(GetOwnedPointCount);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _whose, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetOwnedPoints ({ blockHash, blockNumber, contractAddress, _whose, value, proof }: DeepPartial<GetOwnedPoints>): Promise<GetOwnedPoints> {
+    const repo = this._conn.getRepository(GetOwnedPoints);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _whose, value, proof });
     return repo.save(entity);
   }
@@ -565,6 +669,12 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
+  async saveGetManagerFor ({ blockHash, blockNumber, contractAddress, _proxy, value, proof }: DeepPartial<GetManagerFor>): Promise<GetManagerFor> {
+    const repo = this._conn.getRepository(GetManagerFor);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _proxy, value, proof });
+    return repo.save(entity);
+  }
+
   async saveGetSpawnProxy ({ blockHash, blockNumber, contractAddress, _point, value, proof }: DeepPartial<GetSpawnProxy>): Promise<GetSpawnProxy> {
     const repo = this._conn.getRepository(GetSpawnProxy);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _point, value, proof });
@@ -585,6 +695,12 @@ export class Database implements DatabaseInterface {
 
   async saveGetSpawningForCount ({ blockHash, blockNumber, contractAddress, _proxy, value, proof }: DeepPartial<GetSpawningForCount>): Promise<GetSpawningForCount> {
     const repo = this._conn.getRepository(GetSpawningForCount);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _proxy, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetSpawningFor ({ blockHash, blockNumber, contractAddress, _proxy, value, proof }: DeepPartial<GetSpawningFor>): Promise<GetSpawningFor> {
+    const repo = this._conn.getRepository(GetSpawningFor);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _proxy, value, proof });
     return repo.save(entity);
   }
@@ -613,6 +729,12 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
+  async saveGetVotingFor ({ blockHash, blockNumber, contractAddress, _proxy, value, proof }: DeepPartial<GetVotingFor>): Promise<GetVotingFor> {
+    const repo = this._conn.getRepository(GetVotingFor);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _proxy, value, proof });
+    return repo.save(entity);
+  }
+
   async saveGetTransferProxy ({ blockHash, blockNumber, contractAddress, _point, value, proof }: DeepPartial<GetTransferProxy>): Promise<GetTransferProxy> {
     const repo = this._conn.getRepository(GetTransferProxy);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _point, value, proof });
@@ -633,6 +755,12 @@ export class Database implements DatabaseInterface {
 
   async saveGetTransferringForCount ({ blockHash, blockNumber, contractAddress, _proxy, value, proof }: DeepPartial<GetTransferringForCount>): Promise<GetTransferringForCount> {
     const repo = this._conn.getRepository(GetTransferringForCount);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _proxy, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetTransferringFor ({ blockHash, blockNumber, contractAddress, _proxy, value, proof }: DeepPartial<GetTransferringFor>): Promise<GetTransferringFor> {
+    const repo = this._conn.getRepository(GetTransferringFor);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _proxy, value, proof });
     return repo.save(entity);
   }
@@ -855,34 +983,42 @@ export class Database implements DatabaseInterface {
     this._propColMaps.IsLive = this._getPropertyColumnMapForEntity('IsLive');
     this._propColMaps.GetContinuityNumber = this._getPropertyColumnMapForEntity('GetContinuityNumber');
     this._propColMaps.GetSpawnCount = this._getPropertyColumnMapForEntity('GetSpawnCount');
+    this._propColMaps.GetSpawned = this._getPropertyColumnMapForEntity('GetSpawned');
     this._propColMaps.HasSponsor = this._getPropertyColumnMapForEntity('HasSponsor');
     this._propColMaps.GetSponsor = this._getPropertyColumnMapForEntity('GetSponsor');
     this._propColMaps.IsSponsor = this._getPropertyColumnMapForEntity('IsSponsor');
     this._propColMaps.GetSponsoringCount = this._getPropertyColumnMapForEntity('GetSponsoringCount');
+    this._propColMaps.GetSponsoring = this._getPropertyColumnMapForEntity('GetSponsoring');
     this._propColMaps.IsEscaping = this._getPropertyColumnMapForEntity('IsEscaping');
     this._propColMaps.GetEscapeRequest = this._getPropertyColumnMapForEntity('GetEscapeRequest');
     this._propColMaps.IsRequestingEscapeTo = this._getPropertyColumnMapForEntity('IsRequestingEscapeTo');
     this._propColMaps.GetEscapeRequestsCount = this._getPropertyColumnMapForEntity('GetEscapeRequestsCount');
+    this._propColMaps.GetEscapeRequests = this._getPropertyColumnMapForEntity('GetEscapeRequests');
     this._propColMaps.GetOwner = this._getPropertyColumnMapForEntity('GetOwner');
     this._propColMaps.IsOwner = this._getPropertyColumnMapForEntity('IsOwner');
     this._propColMaps.GetOwnedPointCount = this._getPropertyColumnMapForEntity('GetOwnedPointCount');
+    this._propColMaps.GetOwnedPoints = this._getPropertyColumnMapForEntity('GetOwnedPoints');
     this._propColMaps.GetOwnedPointAtIndex = this._getPropertyColumnMapForEntity('GetOwnedPointAtIndex');
     this._propColMaps.GetManagementProxy = this._getPropertyColumnMapForEntity('GetManagementProxy');
     this._propColMaps.IsManagementProxy = this._getPropertyColumnMapForEntity('IsManagementProxy');
     this._propColMaps.CanManage = this._getPropertyColumnMapForEntity('CanManage');
     this._propColMaps.GetManagerForCount = this._getPropertyColumnMapForEntity('GetManagerForCount');
+    this._propColMaps.GetManagerFor = this._getPropertyColumnMapForEntity('GetManagerFor');
     this._propColMaps.GetSpawnProxy = this._getPropertyColumnMapForEntity('GetSpawnProxy');
     this._propColMaps.IsSpawnProxy = this._getPropertyColumnMapForEntity('IsSpawnProxy');
     this._propColMaps.CanSpawnAs = this._getPropertyColumnMapForEntity('CanSpawnAs');
     this._propColMaps.GetSpawningForCount = this._getPropertyColumnMapForEntity('GetSpawningForCount');
+    this._propColMaps.GetSpawningFor = this._getPropertyColumnMapForEntity('GetSpawningFor');
     this._propColMaps.GetVotingProxy = this._getPropertyColumnMapForEntity('GetVotingProxy');
     this._propColMaps.IsVotingProxy = this._getPropertyColumnMapForEntity('IsVotingProxy');
     this._propColMaps.CanVoteAs = this._getPropertyColumnMapForEntity('CanVoteAs');
     this._propColMaps.GetVotingForCount = this._getPropertyColumnMapForEntity('GetVotingForCount');
+    this._propColMaps.GetVotingFor = this._getPropertyColumnMapForEntity('GetVotingFor');
     this._propColMaps.GetTransferProxy = this._getPropertyColumnMapForEntity('GetTransferProxy');
     this._propColMaps.IsTransferProxy = this._getPropertyColumnMapForEntity('IsTransferProxy');
     this._propColMaps.CanTransfer = this._getPropertyColumnMapForEntity('CanTransfer');
     this._propColMaps.GetTransferringForCount = this._getPropertyColumnMapForEntity('GetTransferringForCount');
+    this._propColMaps.GetTransferringFor = this._getPropertyColumnMapForEntity('GetTransferringFor');
     this._propColMaps.IsOperator = this._getPropertyColumnMapForEntity('IsOperator');
   }
 }

--- a/packages/azimuth-watcher/src/entity/GetEscapeRequests.ts
+++ b/packages/azimuth-watcher/src/entity/GetEscapeRequests.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintTransformer, bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_sponsor'], { unique: true })
+export class GetEscapeRequests {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('numeric', { transformer: bigintTransformer })
+    _sponsor!: bigint;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/entity/GetManagerFor.ts
+++ b/packages/azimuth-watcher/src/entity/GetManagerFor.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_proxy'], { unique: true })
+export class GetManagerFor {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('varchar', { length: 42 })
+    _proxy!: string;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/entity/GetOwnedPoints.ts
+++ b/packages/azimuth-watcher/src/entity/GetOwnedPoints.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_whose'], { unique: true })
+export class GetOwnedPoints {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('varchar', { length: 42 })
+    _whose!: string;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/entity/GetSpawned.ts
+++ b/packages/azimuth-watcher/src/entity/GetSpawned.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintTransformer, bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_point'], { unique: true })
+export class GetSpawned {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('numeric', { transformer: bigintTransformer })
+    _point!: bigint;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/entity/GetSpawningFor.ts
+++ b/packages/azimuth-watcher/src/entity/GetSpawningFor.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_proxy'], { unique: true })
+export class GetSpawningFor {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('varchar', { length: 42 })
+    _proxy!: string;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/entity/GetSponsoring.ts
+++ b/packages/azimuth-watcher/src/entity/GetSponsoring.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintTransformer, bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_sponsor'], { unique: true })
+export class GetSponsoring {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('numeric', { transformer: bigintTransformer })
+    _sponsor!: bigint;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/entity/GetTransferringFor.ts
+++ b/packages/azimuth-watcher/src/entity/GetTransferringFor.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_proxy'], { unique: true })
+export class GetTransferringFor {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('varchar', { length: 42 })
+    _proxy!: string;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/entity/GetVotingFor.ts
+++ b/packages/azimuth-watcher/src/entity/GetVotingFor.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_proxy'], { unique: true })
+export class GetVotingFor {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('varchar', { length: 42 })
+    _proxy!: string;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/azimuth-watcher/src/indexer.ts
+++ b/packages/azimuth-watcher/src/indexer.ts
@@ -318,6 +318,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getSpawned (blockHash: string, contractAddress: string, _point: bigint): Promise<ValueResult> {
+    const entity = await this._db.getGetSpawned({ blockHash, contractAddress, _point });
+    if (entity) {
+      log('getSpawned: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getSpawned: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -328,6 +341,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetSpawned({ blockHash, blockNumber, contractAddress, _point, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -455,6 +470,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getSponsoring (blockHash: string, contractAddress: string, _sponsor: bigint): Promise<ValueResult> {
+    const entity = await this._db.getGetSponsoring({ blockHash, contractAddress, _sponsor });
+    if (entity) {
+      log('getSponsoring: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getSponsoring: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -465,6 +493,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetSponsoring({ blockHash, blockNumber, contractAddress, _sponsor, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -592,6 +622,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getEscapeRequests (blockHash: string, contractAddress: string, _sponsor: bigint): Promise<ValueResult> {
+    const entity = await this._db.getGetEscapeRequests({ blockHash, contractAddress, _sponsor });
+    if (entity) {
+      log('getEscapeRequests: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getEscapeRequests: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -602,6 +645,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetEscapeRequests({ blockHash, blockNumber, contractAddress, _sponsor, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -698,6 +743,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getOwnedPoints (blockHash: string, contractAddress: string, _whose: string): Promise<ValueResult> {
+    const entity = await this._db.getGetOwnedPoints({ blockHash, contractAddress, _whose });
+    if (entity) {
+      log('getOwnedPoints: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getOwnedPoints: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -708,6 +766,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetOwnedPoints({ blockHash, blockNumber, contractAddress, _whose, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -865,6 +925,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getManagerFor (blockHash: string, contractAddress: string, _proxy: string): Promise<ValueResult> {
+    const entity = await this._db.getGetManagerFor({ blockHash, contractAddress, _proxy });
+    if (entity) {
+      log('getManagerFor: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getManagerFor: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -875,6 +948,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetManagerFor({ blockHash, blockNumber, contractAddress, _proxy, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -1001,6 +1076,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getSpawningFor (blockHash: string, contractAddress: string, _proxy: string): Promise<ValueResult> {
+    const entity = await this._db.getGetSpawningFor({ blockHash, contractAddress, _proxy });
+    if (entity) {
+      log('getSpawningFor: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getSpawningFor: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -1011,6 +1099,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetSpawningFor({ blockHash, blockNumber, contractAddress, _proxy, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -1137,6 +1227,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getVotingFor (blockHash: string, contractAddress: string, _proxy: string): Promise<ValueResult> {
+    const entity = await this._db.getGetVotingFor({ blockHash, contractAddress, _proxy });
+    if (entity) {
+      log('getVotingFor: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getVotingFor: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -1147,6 +1250,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetVotingFor({ blockHash, blockNumber, contractAddress, _proxy, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -1273,6 +1378,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getTransferringFor (blockHash: string, contractAddress: string, _proxy: string): Promise<ValueResult> {
+    const entity = await this._db.getGetTransferringFor({ blockHash, contractAddress, _proxy });
+    if (entity) {
+      log('getTransferringFor: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getTransferringFor: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_AZIMUTH);
@@ -1283,6 +1401,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult.map((val: ethers.BigNumber | number) => ethers.BigNumber.from(val).toBigInt());
     const result: ValueResult = { value };
+
+    await this._db.saveGetTransferringFor({ blockHash, blockNumber, contractAddress, _proxy, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }

--- a/packages/censures-watcher/src/client.ts
+++ b/packages/censures-watcher/src/client.ts
@@ -26,6 +26,15 @@ export class Client {
     return getCensuringCount;
   }
 
+  async getGetCensuring (blockHash: string, contractAddress: string, _whose: number): Promise<any> {
+    const { getCensuring } = await this._client.query(
+      gql(queries.getCensuring),
+      { blockHash, contractAddress, _whose }
+    );
+
+    return getCensuring;
+  }
+
   async getGetCensuredByCount (blockHash: string, contractAddress: string, _who: number): Promise<any> {
     const { getCensuredByCount } = await this._client.query(
       gql(queries.getCensuredByCount),
@@ -33,6 +42,15 @@ export class Client {
     );
 
     return getCensuredByCount;
+  }
+
+  async getGetCensuredBy (blockHash: string, contractAddress: string, _who: number): Promise<any> {
+    const { getCensuredBy } = await this._client.query(
+      gql(queries.getCensuredBy),
+      { blockHash, contractAddress, _who }
+    );
+
+    return getCensuredBy;
   }
 
   async getEvents (blockHash: string, contractAddress: string, name: string): Promise<any> {

--- a/packages/censures-watcher/src/database.ts
+++ b/packages/censures-watcher/src/database.ts
@@ -21,9 +21,11 @@ import { StateSyncStatus } from './entity/StateSyncStatus';
 import { BlockProgress } from './entity/BlockProgress';
 import { State } from './entity/State';
 import { GetCensuringCount } from './entity/GetCensuringCount';
+import { GetCensuring } from './entity/GetCensuring';
 import { GetCensuredByCount } from './entity/GetCensuredByCount';
+import { GetCensuredBy } from './entity/GetCensuredBy';
 
-export const ENTITIES = [GetCensuringCount, GetCensuredByCount];
+export const ENTITIES = [GetCensuringCount, GetCensuring, GetCensuredByCount, GetCensuredBy];
 
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions;
@@ -65,8 +67,26 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetCensuring ({ blockHash, contractAddress, _whose }: { blockHash: string, contractAddress: string, _whose: number }): Promise<GetCensuring | undefined> {
+    return this._conn.getRepository(GetCensuring)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _whose
+      });
+  }
+
   async getGetCensuredByCount ({ blockHash, contractAddress, _who }: { blockHash: string, contractAddress: string, _who: number }): Promise<GetCensuredByCount | undefined> {
     return this._conn.getRepository(GetCensuredByCount)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _who
+      });
+  }
+
+  async getGetCensuredBy ({ blockHash, contractAddress, _who }: { blockHash: string, contractAddress: string, _who: number }): Promise<GetCensuredBy | undefined> {
+    return this._conn.getRepository(GetCensuredBy)
       .findOne({
         blockHash,
         contractAddress,
@@ -80,8 +100,20 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
+  async saveGetCensuring ({ blockHash, blockNumber, contractAddress, _whose, value, proof }: DeepPartial<GetCensuring>): Promise<GetCensuring> {
+    const repo = this._conn.getRepository(GetCensuring);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _whose, value, proof });
+    return repo.save(entity);
+  }
+
   async saveGetCensuredByCount ({ blockHash, blockNumber, contractAddress, _who, value, proof }: DeepPartial<GetCensuredByCount>): Promise<GetCensuredByCount> {
     const repo = this._conn.getRepository(GetCensuredByCount);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _who, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetCensuredBy ({ blockHash, blockNumber, contractAddress, _who, value, proof }: DeepPartial<GetCensuredBy>): Promise<GetCensuredBy> {
+    const repo = this._conn.getRepository(GetCensuredBy);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _who, value, proof });
     return repo.save(entity);
   }
@@ -292,6 +324,8 @@ export class Database implements DatabaseInterface {
 
   _setPropColMaps (): void {
     this._propColMaps.GetCensuringCount = this._getPropertyColumnMapForEntity('GetCensuringCount');
+    this._propColMaps.GetCensuring = this._getPropertyColumnMapForEntity('GetCensuring');
     this._propColMaps.GetCensuredByCount = this._getPropertyColumnMapForEntity('GetCensuredByCount');
+    this._propColMaps.GetCensuredBy = this._getPropertyColumnMapForEntity('GetCensuredBy');
   }
 }

--- a/packages/censures-watcher/src/entity/GetCensuredBy.ts
+++ b/packages/censures-watcher/src/entity/GetCensuredBy.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_who'], { unique: true })
+export class GetCensuredBy {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('integer')
+    _who!: number;
+
+  @Column('integer', { array: true })
+    value!: number[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/censures-watcher/src/entity/GetCensuring.ts
+++ b/packages/censures-watcher/src/entity/GetCensuring.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_whose'], { unique: true })
+export class GetCensuring {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('integer')
+    _whose!: number;
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/conditional-star-release-watcher/src/client.ts
+++ b/packages/conditional-star-release-watcher/src/client.ts
@@ -35,6 +35,15 @@ export class Client {
     return verifyBalance;
   }
 
+  async getGetBatches (blockHash: string, contractAddress: string, _participant: string): Promise<any> {
+    const { getBatches } = await this._client.query(
+      gql(queries.getBatches),
+      { blockHash, contractAddress, _participant }
+    );
+
+    return getBatches;
+  }
+
   async getGetBatch (blockHash: string, contractAddress: string, _participant: string, _batch: number): Promise<any> {
     const { getBatch } = await this._client.query(
       gql(queries.getBatch),
@@ -42,6 +51,15 @@ export class Client {
     );
 
     return getBatch;
+  }
+
+  async getGetWithdrawn (blockHash: string, contractAddress: string, _participant: string): Promise<any> {
+    const { getWithdrawn } = await this._client.query(
+      gql(queries.getWithdrawn),
+      { blockHash, contractAddress, _participant }
+    );
+
+    return getWithdrawn;
   }
 
   async getGetWithdrawnFromBatch (blockHash: string, contractAddress: string, _participant: string, _batch: number): Promise<any> {
@@ -53,6 +71,15 @@ export class Client {
     return getWithdrawnFromBatch;
   }
 
+  async getGetForfeited (blockHash: string, contractAddress: string, _participant: string): Promise<any> {
+    const { getForfeited } = await this._client.query(
+      gql(queries.getForfeited),
+      { blockHash, contractAddress, _participant }
+    );
+
+    return getForfeited;
+  }
+
   async getHasForfeitedBatch (blockHash: string, contractAddress: string, _participant: string, _batch: number): Promise<any> {
     const { hasForfeitedBatch } = await this._client.query(
       gql(queries.hasForfeitedBatch),
@@ -60,6 +87,24 @@ export class Client {
     );
 
     return hasForfeitedBatch;
+  }
+
+  async getGetRemainingStars (blockHash: string, contractAddress: string, _participant: string): Promise<any> {
+    const { getRemainingStars } = await this._client.query(
+      gql(queries.getRemainingStars),
+      { blockHash, contractAddress, _participant }
+    );
+
+    return getRemainingStars;
+  }
+
+  async getGetConditionsState (blockHash: string, contractAddress: string): Promise<any> {
+    const { getConditionsState } = await this._client.query(
+      gql(queries.getConditionsState),
+      { blockHash, contractAddress }
+    );
+
+    return getConditionsState;
   }
 
   async getEvents (blockHash: string, contractAddress: string, name: string): Promise<any> {

--- a/packages/conditional-star-release-watcher/src/database.ts
+++ b/packages/conditional-star-release-watcher/src/database.ts
@@ -22,11 +22,16 @@ import { BlockProgress } from './entity/BlockProgress';
 import { State } from './entity/State';
 import { WithdrawLimit } from './entity/WithdrawLimit';
 import { VerifyBalance } from './entity/VerifyBalance';
+import { GetBatches } from './entity/GetBatches';
 import { GetBatch } from './entity/GetBatch';
+import { GetWithdrawn } from './entity/GetWithdrawn';
 import { GetWithdrawnFromBatch } from './entity/GetWithdrawnFromBatch';
+import { GetForfeited } from './entity/GetForfeited';
 import { HasForfeitedBatch } from './entity/HasForfeitedBatch';
+import { GetRemainingStars } from './entity/GetRemainingStars';
+import { GetConditionsState } from './entity/GetConditionsState';
 
-export const ENTITIES = [WithdrawLimit, VerifyBalance, GetBatch, GetWithdrawnFromBatch, HasForfeitedBatch];
+export const ENTITIES = [WithdrawLimit, VerifyBalance, GetBatches, GetBatch, GetWithdrawn, GetWithdrawnFromBatch, GetForfeited, HasForfeitedBatch, GetRemainingStars, GetConditionsState];
 
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions;
@@ -78,6 +83,15 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetBatches ({ blockHash, contractAddress, _participant }: { blockHash: string, contractAddress: string, _participant: string }): Promise<GetBatches | undefined> {
+    return this._conn.getRepository(GetBatches)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _participant
+      });
+  }
+
   async getGetBatch ({ blockHash, contractAddress, _participant, _batch }: { blockHash: string, contractAddress: string, _participant: string, _batch: number }): Promise<GetBatch | undefined> {
     return this._conn.getRepository(GetBatch)
       .findOne({
@@ -85,6 +99,15 @@ export class Database implements DatabaseInterface {
         contractAddress,
         _participant,
         _batch
+      });
+  }
+
+  async getGetWithdrawn ({ blockHash, contractAddress, _participant }: { blockHash: string, contractAddress: string, _participant: string }): Promise<GetWithdrawn | undefined> {
+    return this._conn.getRepository(GetWithdrawn)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _participant
       });
   }
 
@@ -98,6 +121,15 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetForfeited ({ blockHash, contractAddress, _participant }: { blockHash: string, contractAddress: string, _participant: string }): Promise<GetForfeited | undefined> {
+    return this._conn.getRepository(GetForfeited)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _participant
+      });
+  }
+
   async getHasForfeitedBatch ({ blockHash, contractAddress, _participant, _batch }: { blockHash: string, contractAddress: string, _participant: string, _batch: number }): Promise<HasForfeitedBatch | undefined> {
     return this._conn.getRepository(HasForfeitedBatch)
       .findOne({
@@ -105,6 +137,23 @@ export class Database implements DatabaseInterface {
         contractAddress,
         _participant,
         _batch
+      });
+  }
+
+  async getGetRemainingStars ({ blockHash, contractAddress, _participant }: { blockHash: string, contractAddress: string, _participant: string }): Promise<GetRemainingStars | undefined> {
+    return this._conn.getRepository(GetRemainingStars)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _participant
+      });
+  }
+
+  async getGetConditionsState ({ blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<GetConditionsState | undefined> {
+    return this._conn.getRepository(GetConditionsState)
+      .findOne({
+        blockHash,
+        contractAddress
       });
   }
 
@@ -120,9 +169,21 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
+  async saveGetBatches ({ blockHash, blockNumber, contractAddress, _participant, value, proof }: DeepPartial<GetBatches>): Promise<GetBatches> {
+    const repo = this._conn.getRepository(GetBatches);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, value, proof });
+    return repo.save(entity);
+  }
+
   async saveGetBatch ({ blockHash, blockNumber, contractAddress, _participant, _batch, value, proof }: DeepPartial<GetBatch>): Promise<GetBatch> {
     const repo = this._conn.getRepository(GetBatch);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, _batch, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetWithdrawn ({ blockHash, blockNumber, contractAddress, _participant, value, proof }: DeepPartial<GetWithdrawn>): Promise<GetWithdrawn> {
+    const repo = this._conn.getRepository(GetWithdrawn);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, value, proof });
     return repo.save(entity);
   }
 
@@ -132,9 +193,27 @@ export class Database implements DatabaseInterface {
     return repo.save(entity);
   }
 
+  async saveGetForfeited ({ blockHash, blockNumber, contractAddress, _participant, value, proof }: DeepPartial<GetForfeited>): Promise<GetForfeited> {
+    const repo = this._conn.getRepository(GetForfeited);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, value, proof });
+    return repo.save(entity);
+  }
+
   async saveHasForfeitedBatch ({ blockHash, blockNumber, contractAddress, _participant, _batch, value, proof }: DeepPartial<HasForfeitedBatch>): Promise<HasForfeitedBatch> {
     const repo = this._conn.getRepository(HasForfeitedBatch);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, _batch, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetRemainingStars ({ blockHash, blockNumber, contractAddress, _participant, value, proof }: DeepPartial<GetRemainingStars>): Promise<GetRemainingStars> {
+    const repo = this._conn.getRepository(GetRemainingStars);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetConditionsState ({ blockHash, blockNumber, contractAddress, value0, value1, value2, value3, proof }: DeepPartial<GetConditionsState>): Promise<GetConditionsState> {
+    const repo = this._conn.getRepository(GetConditionsState);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, value0, value1, value2, value3, proof });
     return repo.save(entity);
   }
 
@@ -345,8 +424,13 @@ export class Database implements DatabaseInterface {
   _setPropColMaps (): void {
     this._propColMaps.WithdrawLimit = this._getPropertyColumnMapForEntity('WithdrawLimit');
     this._propColMaps.VerifyBalance = this._getPropertyColumnMapForEntity('VerifyBalance');
+    this._propColMaps.GetBatches = this._getPropertyColumnMapForEntity('GetBatches');
     this._propColMaps.GetBatch = this._getPropertyColumnMapForEntity('GetBatch');
+    this._propColMaps.GetWithdrawn = this._getPropertyColumnMapForEntity('GetWithdrawn');
     this._propColMaps.GetWithdrawnFromBatch = this._getPropertyColumnMapForEntity('GetWithdrawnFromBatch');
+    this._propColMaps.GetForfeited = this._getPropertyColumnMapForEntity('GetForfeited');
     this._propColMaps.HasForfeitedBatch = this._getPropertyColumnMapForEntity('HasForfeitedBatch');
+    this._propColMaps.GetRemainingStars = this._getPropertyColumnMapForEntity('GetRemainingStars');
+    this._propColMaps.GetConditionsState = this._getPropertyColumnMapForEntity('GetConditionsState');
   }
 }

--- a/packages/conditional-star-release-watcher/src/entity/GetBatches.ts
+++ b/packages/conditional-star-release-watcher/src/entity/GetBatches.ts
@@ -22,10 +22,7 @@ export class GetBatches {
   @Column('varchar', { length: 42 })
     _participant!: string;
 
-  @Column('integer', {
-    array: true,
-    nullable: false
-  })
+  @Column('integer', { array: true })
     value!: number[];
 
   @Column('text', { nullable: true })

--- a/packages/conditional-star-release-watcher/src/entity/GetConditionsState.ts
+++ b/packages/conditional-star-release-watcher/src/entity/GetConditionsState.ts
@@ -1,0 +1,37 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { bigintArrayTransformer } from '@cerc-io/util';
+
+@Entity()
+@Index(['blockHash', 'contractAddress'], { unique: true })
+export class GetConditionsState {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('varchar', { array: true })
+    value0!: string[];
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value1!: bigint[];
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value2!: bigint[];
+
+  @Column('numeric', { array: true, transformer: bigintArrayTransformer })
+    value3!: bigint[];
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/conditional-star-release-watcher/src/entity/GetForfeited.ts
+++ b/packages/conditional-star-release-watcher/src/entity/GetForfeited.ts
@@ -22,10 +22,7 @@ export class GetForfeited {
   @Column('varchar', { length: 42 })
     _participant!: string;
 
-  @Column('boolean', {
-    array: true,
-    nullable: true
-  })
+  @Column('boolean', { array: true })
     value!: boolean[];
 
   @Column('text', { nullable: true })

--- a/packages/conditional-star-release-watcher/src/entity/GetRemainingStars.ts
+++ b/packages/conditional-star-release-watcher/src/entity/GetRemainingStars.ts
@@ -22,10 +22,7 @@ export class GetRemainingStars {
   @Column('varchar', { length: 42 })
     _participant!: string;
 
-  @Column('integer', {
-    array: true,
-    nullable: false
-  })
+  @Column('integer', { array: true })
     value!: number[];
 
   @Column('text', { nullable: true })

--- a/packages/conditional-star-release-watcher/src/entity/GetWithdrawn.ts
+++ b/packages/conditional-star-release-watcher/src/entity/GetWithdrawn.ts
@@ -22,10 +22,7 @@ export class GetWithdrawn {
   @Column('varchar', { length: 42 })
     _participant!: string;
 
-  @Column('integer', {
-    array: true,
-    nullable: false
-  })
+  @Column('integer', { array: true })
     value!: number[];
 
   @Column('text', { nullable: true })

--- a/packages/conditional-star-release-watcher/src/indexer.ts
+++ b/packages/conditional-star-release-watcher/src/indexer.ts
@@ -154,6 +154,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getBatches (blockHash: string, contractAddress: string, _participant: string): Promise<ValueResult> {
+    const entity = await this._db.getGetBatches({ blockHash, contractAddress, _participant });
+    if (entity) {
+      log('getBatches: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getBatches: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_CONDITIONALSTARRELEASE);
@@ -164,6 +177,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult;
     const result: ValueResult = { value };
+
+    await this._db.saveGetBatches({ blockHash, blockNumber, contractAddress, _participant, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -199,6 +214,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getWithdrawn (blockHash: string, contractAddress: string, _participant: string): Promise<ValueResult> {
+    const entity = await this._db.getGetWithdrawn({ blockHash, contractAddress, _participant });
+    if (entity) {
+      log('getWithdrawn: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getWithdrawn: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_CONDITIONALSTARRELEASE);
@@ -209,6 +237,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult;
     const result: ValueResult = { value };
+
+    await this._db.saveGetWithdrawn({ blockHash, blockNumber, contractAddress, _participant, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -244,6 +274,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getForfeited (blockHash: string, contractAddress: string, _participant: string): Promise<ValueResult> {
+    const entity = await this._db.getGetForfeited({ blockHash, contractAddress, _participant });
+    if (entity) {
+      log('getForfeited: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getForfeited: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_CONDITIONALSTARRELEASE);
@@ -254,6 +297,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult;
     const result: ValueResult = { value };
+
+    await this._db.saveGetForfeited({ blockHash, blockNumber, contractAddress, _participant, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -289,6 +334,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getRemainingStars (blockHash: string, contractAddress: string, _participant: string): Promise<ValueResult> {
+    const entity = await this._db.getGetRemainingStars({ blockHash, contractAddress, _participant });
+    if (entity) {
+      log('getRemainingStars: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getRemainingStars: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_CONDITIONALSTARRELEASE);
@@ -300,10 +358,30 @@ export class Indexer implements IndexerInterface {
     const value = contractResult;
     const result: ValueResult = { value };
 
+    await this._db.saveGetRemainingStars({ blockHash, blockNumber, contractAddress, _participant, value: result.value, proof: JSONbigNative.stringify(result.proof) });
+
     return result;
   }
 
   async getConditionsState (blockHash: string, contractAddress: string): Promise<ValueResult> {
+    const entity = await this._db.getGetConditionsState({ blockHash, contractAddress });
+    if (entity) {
+      log('getConditionsState: db hit.');
+
+      return {
+        value: {
+          value0: entity.value0,
+          value1: entity.value1,
+          value2: entity.value2,
+          value3: entity.value3
+        },
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getConditionsState: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_CONDITIONALSTARRELEASE);
@@ -320,6 +398,8 @@ export class Indexer implements IndexerInterface {
     };
 
     const result: ValueResult = { value };
+
+    await this._db.saveGetConditionsState({ blockHash, blockNumber, contractAddress, value0: value.value0, value1: value.value1, value2: value.value2, value3: value.value3, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }

--- a/packages/linear-star-release-watcher/src/client.ts
+++ b/packages/linear-star-release-watcher/src/client.ts
@@ -35,6 +35,15 @@ export class Client {
     return verifyBalance;
   }
 
+  async getGetRemainingStars (blockHash: string, contractAddress: string, _participant: string): Promise<any> {
+    const { getRemainingStars } = await this._client.query(
+      gql(queries.getRemainingStars),
+      { blockHash, contractAddress, _participant }
+    );
+
+    return getRemainingStars;
+  }
+
   async getEvents (blockHash: string, contractAddress: string, name: string): Promise<any> {
     const { events } = await this._client.query(
       gql(queries.events),

--- a/packages/linear-star-release-watcher/src/database.ts
+++ b/packages/linear-star-release-watcher/src/database.ts
@@ -22,8 +22,9 @@ import { BlockProgress } from './entity/BlockProgress';
 import { State } from './entity/State';
 import { WithdrawLimit } from './entity/WithdrawLimit';
 import { VerifyBalance } from './entity/VerifyBalance';
+import { GetRemainingStars } from './entity/GetRemainingStars';
 
-export const ENTITIES = [WithdrawLimit, VerifyBalance];
+export const ENTITIES = [WithdrawLimit, VerifyBalance, GetRemainingStars];
 
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions;
@@ -74,6 +75,15 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetRemainingStars ({ blockHash, contractAddress, _participant }: { blockHash: string, contractAddress: string, _participant: string }): Promise<GetRemainingStars | undefined> {
+    return this._conn.getRepository(GetRemainingStars)
+      .findOne({
+        blockHash,
+        contractAddress,
+        _participant
+      });
+  }
+
   async saveWithdrawLimit ({ blockHash, blockNumber, contractAddress, _participant, value, proof }: DeepPartial<WithdrawLimit>): Promise<WithdrawLimit> {
     const repo = this._conn.getRepository(WithdrawLimit);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, value, proof });
@@ -82,6 +92,12 @@ export class Database implements DatabaseInterface {
 
   async saveVerifyBalance ({ blockHash, blockNumber, contractAddress, _participant, value, proof }: DeepPartial<VerifyBalance>): Promise<VerifyBalance> {
     const repo = this._conn.getRepository(VerifyBalance);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetRemainingStars ({ blockHash, blockNumber, contractAddress, _participant, value, proof }: DeepPartial<GetRemainingStars>): Promise<GetRemainingStars> {
+    const repo = this._conn.getRepository(GetRemainingStars);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, _participant, value, proof });
     return repo.save(entity);
   }
@@ -293,5 +309,6 @@ export class Database implements DatabaseInterface {
   _setPropColMaps (): void {
     this._propColMaps.WithdrawLimit = this._getPropertyColumnMapForEntity('WithdrawLimit');
     this._propColMaps.VerifyBalance = this._getPropertyColumnMapForEntity('VerifyBalance');
+    this._propColMaps.GetRemainingStars = this._getPropertyColumnMapForEntity('GetRemainingStars');
   }
 }

--- a/packages/linear-star-release-watcher/src/entity/GetRemainingStars.ts
+++ b/packages/linear-star-release-watcher/src/entity/GetRemainingStars.ts
@@ -23,7 +23,7 @@ export class GetRemainingStars {
     _participant!: string;
 
   @Column('integer', { array: true })
-    value!: number;
+    value!: number[];
 
   @Column('text', { nullable: true })
     proof!: string;

--- a/packages/linear-star-release-watcher/src/entity/GetRemainingStars.ts
+++ b/packages/linear-star-release-watcher/src/entity/GetRemainingStars.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+
+@Entity()
+@Index(['blockHash', 'contractAddress', '_participant'], { unique: true })
+export class GetRemainingStars {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column('varchar', { length: 66 })
+    blockHash!: string;
+
+  @Column('integer')
+    blockNumber!: number;
+
+  @Column('varchar', { length: 42 })
+    contractAddress!: string;
+
+  @Column('varchar', { length: 42 })
+    _participant!: string;
+
+  @Column('integer', { array: true })
+    value!: number;
+
+  @Column('text', { nullable: true })
+    proof!: string;
+}

--- a/packages/polls-watcher/src/client.ts
+++ b/packages/polls-watcher/src/client.ts
@@ -17,6 +17,15 @@ export class Client {
     this._client = new GraphQLClient(config);
   }
 
+  async getGetUpgradeProposals (blockHash: string, contractAddress: string): Promise<any> {
+    const { getUpgradeProposals } = await this._client.query(
+      gql(queries.getUpgradeProposals),
+      { blockHash, contractAddress }
+    );
+
+    return getUpgradeProposals;
+  }
+
   async getGetUpgradeProposalCount (blockHash: string, contractAddress: string): Promise<any> {
     const { getUpgradeProposalCount } = await this._client.query(
       gql(queries.getUpgradeProposalCount),
@@ -26,6 +35,15 @@ export class Client {
     return getUpgradeProposalCount;
   }
 
+  async getGetDocumentProposals (blockHash: string, contractAddress: string): Promise<any> {
+    const { getDocumentProposals } = await this._client.query(
+      gql(queries.getDocumentProposals),
+      { blockHash, contractAddress }
+    );
+
+    return getDocumentProposals;
+  }
+
   async getGetDocumentProposalCount (blockHash: string, contractAddress: string): Promise<any> {
     const { getDocumentProposalCount } = await this._client.query(
       gql(queries.getDocumentProposalCount),
@@ -33,6 +51,15 @@ export class Client {
     );
 
     return getDocumentProposalCount;
+  }
+
+  async getGetDocumentMajorities (blockHash: string, contractAddress: string): Promise<any> {
+    const { getDocumentMajorities } = await this._client.query(
+      gql(queries.getDocumentMajorities),
+      { blockHash, contractAddress }
+    );
+
+    return getDocumentMajorities;
   }
 
   async getHasVotedOnUpgradePoll (blockHash: string, contractAddress: string, _galaxy: number, _proposal: string): Promise<any> {

--- a/packages/polls-watcher/src/database.ts
+++ b/packages/polls-watcher/src/database.ts
@@ -20,12 +20,15 @@ import { SyncStatus } from './entity/SyncStatus';
 import { StateSyncStatus } from './entity/StateSyncStatus';
 import { BlockProgress } from './entity/BlockProgress';
 import { State } from './entity/State';
+import { GetUpgradeProposals } from './entity/GetUpgradeProposals';
 import { GetUpgradeProposalCount } from './entity/GetUpgradeProposalCount';
+import { GetDocumentProposals } from './entity/GetDocumentProposals';
 import { GetDocumentProposalCount } from './entity/GetDocumentProposalCount';
+import { GetDocumentMajorities } from './entity/GetDocumentMajorities';
 import { HasVotedOnUpgradePoll } from './entity/HasVotedOnUpgradePoll';
 import { HasVotedOnDocumentPoll } from './entity/HasVotedOnDocumentPoll';
 
-export const ENTITIES = [GetUpgradeProposalCount, GetDocumentProposalCount, HasVotedOnUpgradePoll, HasVotedOnDocumentPoll];
+export const ENTITIES = [GetUpgradeProposals, GetUpgradeProposalCount, GetDocumentProposals, GetDocumentProposalCount, GetDocumentMajorities, HasVotedOnUpgradePoll, HasVotedOnDocumentPoll];
 
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions;
@@ -58,6 +61,14 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.close();
   }
 
+  async getGetUpgradeProposals ({ blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<GetUpgradeProposals | undefined> {
+    return this._conn.getRepository(GetUpgradeProposals)
+      .findOne({
+        blockHash,
+        contractAddress
+      });
+  }
+
   async getGetUpgradeProposalCount ({ blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<GetUpgradeProposalCount | undefined> {
     return this._conn.getRepository(GetUpgradeProposalCount)
       .findOne({
@@ -66,8 +77,24 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async getGetDocumentProposals ({ blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<GetDocumentProposals | undefined> {
+    return this._conn.getRepository(GetDocumentProposals)
+      .findOne({
+        blockHash,
+        contractAddress
+      });
+  }
+
   async getGetDocumentProposalCount ({ blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<GetDocumentProposalCount | undefined> {
     return this._conn.getRepository(GetDocumentProposalCount)
+      .findOne({
+        blockHash,
+        contractAddress
+      });
+  }
+
+  async getGetDocumentMajorities ({ blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<GetDocumentMajorities | undefined> {
+    return this._conn.getRepository(GetDocumentMajorities)
       .findOne({
         blockHash,
         contractAddress
@@ -94,14 +121,32 @@ export class Database implements DatabaseInterface {
       });
   }
 
+  async saveGetUpgradeProposals ({ blockHash, blockNumber, contractAddress, value, proof }: DeepPartial<GetUpgradeProposals>): Promise<GetUpgradeProposals> {
+    const repo = this._conn.getRepository(GetUpgradeProposals);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, value, proof });
+    return repo.save(entity);
+  }
+
   async saveGetUpgradeProposalCount ({ blockHash, blockNumber, contractAddress, value, proof }: DeepPartial<GetUpgradeProposalCount>): Promise<GetUpgradeProposalCount> {
     const repo = this._conn.getRepository(GetUpgradeProposalCount);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, value, proof });
     return repo.save(entity);
   }
 
+  async saveGetDocumentProposals ({ blockHash, blockNumber, contractAddress, value, proof }: DeepPartial<GetDocumentProposals>): Promise<GetDocumentProposals> {
+    const repo = this._conn.getRepository(GetDocumentProposals);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, value, proof });
+    return repo.save(entity);
+  }
+
   async saveGetDocumentProposalCount ({ blockHash, blockNumber, contractAddress, value, proof }: DeepPartial<GetDocumentProposalCount>): Promise<GetDocumentProposalCount> {
     const repo = this._conn.getRepository(GetDocumentProposalCount);
+    const entity = repo.create({ blockHash, blockNumber, contractAddress, value, proof });
+    return repo.save(entity);
+  }
+
+  async saveGetDocumentMajorities ({ blockHash, blockNumber, contractAddress, value, proof }: DeepPartial<GetDocumentMajorities>): Promise<GetDocumentMajorities> {
+    const repo = this._conn.getRepository(GetDocumentMajorities);
     const entity = repo.create({ blockHash, blockNumber, contractAddress, value, proof });
     return repo.save(entity);
   }
@@ -323,8 +368,11 @@ export class Database implements DatabaseInterface {
   }
 
   _setPropColMaps (): void {
+    this._propColMaps.GetUpgradeProposals = this._getPropertyColumnMapForEntity('GetUpgradeProposals');
     this._propColMaps.GetUpgradeProposalCount = this._getPropertyColumnMapForEntity('GetUpgradeProposalCount');
+    this._propColMaps.GetDocumentProposals = this._getPropertyColumnMapForEntity('GetDocumentProposals');
     this._propColMaps.GetDocumentProposalCount = this._getPropertyColumnMapForEntity('GetDocumentProposalCount');
+    this._propColMaps.GetDocumentMajorities = this._getPropertyColumnMapForEntity('GetDocumentMajorities');
     this._propColMaps.HasVotedOnUpgradePoll = this._getPropertyColumnMapForEntity('HasVotedOnUpgradePoll');
     this._propColMaps.HasVotedOnDocumentPoll = this._getPropertyColumnMapForEntity('HasVotedOnDocumentPoll');
   }

--- a/packages/polls-watcher/src/entity/GetDocumentMajorities.ts
+++ b/packages/polls-watcher/src/entity/GetDocumentMajorities.ts
@@ -20,7 +20,7 @@ export class GetDocumentMajorities {
     contractAddress!: string;
 
   @Column('varchar', { array: true })
-    value!: string;
+    value!: string[];
 
   @Column('text', { nullable: true })
     proof!: string;

--- a/packages/polls-watcher/src/entity/GetDocumentMajorities.ts
+++ b/packages/polls-watcher/src/entity/GetDocumentMajorities.ts
@@ -19,8 +19,8 @@ export class GetDocumentMajorities {
   @Column('varchar', { length: 42 })
     contractAddress!: string;
 
-  @Column('simple-array', { nullable: false })
-    value!: string[];
+  @Column('varchar', { array: true })
+    value!: string;
 
   @Column('text', { nullable: true })
     proof!: string;

--- a/packages/polls-watcher/src/entity/GetDocumentProposals.ts
+++ b/packages/polls-watcher/src/entity/GetDocumentProposals.ts
@@ -19,8 +19,8 @@ export class GetDocumentProposals {
   @Column('varchar', { length: 42 })
     contractAddress!: string;
 
-  @Column('simple-array', { nullable: false })
-    value!: string[];
+  @Column('varchar', { array: true })
+    value!: string;
 
   @Column('text', { nullable: true })
     proof!: string;

--- a/packages/polls-watcher/src/entity/GetDocumentProposals.ts
+++ b/packages/polls-watcher/src/entity/GetDocumentProposals.ts
@@ -20,7 +20,7 @@ export class GetDocumentProposals {
     contractAddress!: string;
 
   @Column('varchar', { array: true })
-    value!: string;
+    value!: string[];
 
   @Column('text', { nullable: true })
     proof!: string;

--- a/packages/polls-watcher/src/entity/GetUpgradeProposals.ts
+++ b/packages/polls-watcher/src/entity/GetUpgradeProposals.ts
@@ -20,7 +20,7 @@ export class GetUpgradeProposals {
     contractAddress!: string;
 
   @Column('varchar', { array: true })
-    value!: string;
+    value!: string[];
 
   @Column('text', { nullable: true })
     proof!: string;

--- a/packages/polls-watcher/src/entity/GetUpgradeProposals.ts
+++ b/packages/polls-watcher/src/entity/GetUpgradeProposals.ts
@@ -19,8 +19,8 @@ export class GetUpgradeProposals {
   @Column('varchar', { length: 42 })
     contractAddress!: string;
 
-  @Column('simple-array', { nullable: false })
-    value!: string[];
+  @Column('varchar', { array: true })
+    value!: string;
 
   @Column('text', { nullable: true })
     proof!: string;

--- a/packages/polls-watcher/src/indexer.ts
+++ b/packages/polls-watcher/src/indexer.ts
@@ -94,6 +94,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getUpgradeProposals (blockHash: string, contractAddress: string): Promise<ValueResult> {
+    const entity = await this._db.getGetUpgradeProposals({ blockHash, contractAddress });
+    if (entity) {
+      log('getUpgradeProposals: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getUpgradeProposals: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_POLLS);
@@ -104,6 +117,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult;
     const result: ValueResult = { value };
+
+    await this._db.saveGetUpgradeProposals({ blockHash, blockNumber, contractAddress, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -140,6 +155,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getDocumentProposals (blockHash: string, contractAddress: string): Promise<ValueResult> {
+    const entity = await this._db.getGetDocumentProposals({ blockHash, contractAddress });
+    if (entity) {
+      log('getDocumentProposals: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getDocumentProposals: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_POLLS);
@@ -150,6 +178,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult;
     const result: ValueResult = { value };
+
+    await this._db.saveGetDocumentProposals({ blockHash, blockNumber, contractAddress, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }
@@ -186,6 +216,19 @@ export class Indexer implements IndexerInterface {
   }
 
   async getDocumentMajorities (blockHash: string, contractAddress: string): Promise<ValueResult> {
+    const entity = await this._db.getGetDocumentMajorities({ blockHash, contractAddress });
+    if (entity) {
+      log('getDocumentMajorities: db hit.');
+
+      return {
+        value: entity.value,
+        proof: JSON.parse(entity.proof)
+      };
+    }
+
+    const { block: { number } } = await this._ethClient.getBlockByHash(blockHash);
+    const blockNumber = ethers.BigNumber.from(number).toNumber();
+
     log('getDocumentMajorities: db miss, fetching from upstream server');
 
     const abi = this._abiMap.get(KIND_POLLS);
@@ -196,6 +239,8 @@ export class Indexer implements IndexerInterface {
 
     const value = contractResult;
     const result: ValueResult = { value };
+
+    await this._db.saveGetDocumentMajorities({ blockHash, blockNumber, contractAddress, value: result.value, proof: JSONbigNative.stringify(result.proof) });
 
     return result;
   }


### PR DESCRIPTION
Part of cerc-io/watcher-ts#351

Generated watchers for following contracts:
- LinearStarRelease
- Polls
- ConditionalStarRelease
- Azimuth
- Censures