### PR TITLE
[WIP] Use apollo federation to proxy GQL queries to multiple watchers

### DIFF
--- a/packages/azimuth-watcher/environments/local.toml
+++ b/packages/azimuth-watcher/environments/local.toml
@@ -1,6 +1,6 @@
 [server]
   host = "127.0.0.1"
-  port = 3009
+  port = 3001
   kind = "lazy"
 
   # Checkpointing state.
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/packages/azimuth-watcher/src/subgraph-schema.gql
+++ b/packages/azimuth-watcher/src/subgraph-schema.gql
@@ -1,0 +1,233 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable", "@inaccessible"])
+
+directive @cacheControl(maxAge: Int, inheritMaxAge: Boolean, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+enum CacheControlScope {
+  PUBLIC
+  PRIVATE
+}
+
+scalar BigInt
+
+scalar BigDecimal
+
+scalar Bytes
+
+type Proof @shareable {
+  data: String!
+}
+
+type _Block_ @shareable {
+  cid: String!
+  hash: String!
+  number: Int!
+  timestamp: Int!
+  parentHash: String!
+}
+
+type _Transaction_ @shareable {
+  hash: String!
+  index: Int!
+  from: String!
+  to: String!
+}
+
+type ResultEvent @shareable {
+  block: _Block_!
+  tx: _Transaction_!
+  contract: String!
+  eventIndex: Int!
+  event: Event! @inaccessible
+  proof: Proof
+}
+
+union Event = OwnerChangedEvent | ActivatedEvent | SpawnedEvent | EscapeRequestedEvent | EscapeCanceledEvent | EscapeAcceptedEvent | LostSponsorEvent | ChangedKeysEvent | BrokeContinuityEvent | ChangedSpawnProxyEvent | ChangedTransferProxyEvent | ChangedManagementProxyEvent | ChangedVotingProxyEvent | ChangedDnsEvent | OwnershipRenouncedEvent | OwnershipTransferredEvent
+
+type OwnerChangedEvent {
+  point: BigInt!
+  owner: String!
+}
+
+type ActivatedEvent {
+  point: BigInt!
+}
+
+type SpawnedEvent {
+  prefix: BigInt!
+  child: BigInt!
+}
+
+type EscapeRequestedEvent {
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+type EscapeCanceledEvent {
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+type EscapeAcceptedEvent {
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+type LostSponsorEvent {
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+type ChangedKeysEvent {
+  point: BigInt!
+  encryptionKey: String!
+  authenticationKey: String!
+  cryptoSuiteVersion: BigInt!
+  keyRevisionNumber: BigInt!
+}
+
+type BrokeContinuityEvent {
+  point: BigInt!
+  number: BigInt!
+}
+
+type ChangedSpawnProxyEvent {
+  point: BigInt!
+  spawnProxy: String!
+}
+
+type ChangedTransferProxyEvent {
+  point: BigInt!
+  transferProxy: String!
+}
+
+type ChangedManagementProxyEvent {
+  point: BigInt!
+  managementProxy: String!
+}
+
+type ChangedVotingProxyEvent {
+  point: BigInt!
+  votingProxy: String!
+}
+
+type ChangedDnsEvent {
+  primary: String!
+  secondary: String!
+  tertiary: String!
+}
+
+type OwnershipRenouncedEvent @shareable {
+  previousOwner: String!
+}
+
+type OwnershipTransferredEvent @shareable {
+  previousOwner: String!
+  newOwner: String!
+}
+
+type ResultBoolean @shareable {
+  value: Boolean!
+  proof: Proof
+}
+
+type ResultGetKeysType {
+  value: GetKeysType!
+  proof: Proof
+}
+
+type GetKeysType {
+  value0: String!
+  value1: String!
+  value2: BigInt!
+  value3: BigInt!
+}
+
+type ResultBigInt @shareable {
+  value: BigInt!
+  proof: Proof
+}
+
+type ResultBigIntArray @shareable {
+  value: [BigInt!]!
+  proof: Proof
+}
+
+type ResultString @shareable {
+  value: String!
+  proof: Proof
+}
+
+type SyncStatus @shareable {
+  latestIndexedBlockHash: String!
+  latestIndexedBlockNumber: Int!
+  latestCanonicalBlockHash: String!
+  latestCanonicalBlockNumber: Int!
+}
+
+type ResultState @shareable {
+  block: _Block_!
+  contractAddress: String!
+  cid: String!
+  kind: String!
+  data: String!
+}
+
+type Query {
+  events(blockHash: String!, contractAddress: String!, name: String): [ResultEvent!] @shareable
+  eventsInRange(fromBlockNumber: Int!, toBlockNumber: Int!): [ResultEvent!] @shareable
+  isActive(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean!
+  getKeys(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultGetKeysType!
+  getKeyRevisionNumber(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt!
+  hasBeenLinked(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean!
+  isLive(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean!
+  getContinuityNumber(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt!
+  getSpawnCount(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt!
+  getSpawned(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigIntArray!
+  hasSponsor(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean!
+  getSponsor(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt!
+  isSponsor(blockHash: String!, contractAddress: String!, _point: BigInt!, _sponsor: BigInt!): ResultBoolean!
+  getSponsoringCount(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigInt!
+  getSponsoring(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigIntArray!
+  isEscaping(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean!
+  getEscapeRequest(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt!
+  isRequestingEscapeTo(blockHash: String!, contractAddress: String!, _point: BigInt!, _sponsor: BigInt!): ResultBoolean!
+  getEscapeRequestsCount(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigInt!
+  getEscapeRequests(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigIntArray!
+  getOwner(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString!
+  isOwner(blockHash: String!, contractAddress: String!, _point: BigInt!, _address: String!): ResultBoolean!
+  getOwnedPointCount(blockHash: String!, contractAddress: String!, _whose: String!): ResultBigInt!
+  getOwnedPoints(blockHash: String!, contractAddress: String!, _whose: String!): ResultBigIntArray!
+  getOwnedPointAtIndex(blockHash: String!, contractAddress: String!, _whose: String!, _index: BigInt!): ResultBigInt!
+  getManagementProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString!
+  isManagementProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean!
+  canManage(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean!
+  getManagerForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt!
+  getManagerFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray!
+  getSpawnProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString!
+  isSpawnProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean!
+  canSpawnAs(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean!
+  getSpawningForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt!
+  getSpawningFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray!
+  getVotingProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString!
+  isVotingProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean!
+  canVoteAs(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean!
+  getVotingForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt!
+  getVotingFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray!
+  getTransferProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString!
+  isTransferProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean!
+  canTransfer(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean!
+  getTransferringForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt!
+  getTransferringFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray!
+  isOperator(blockHash: String!, contractAddress: String!, _owner: String!, _operator: String!): ResultBoolean!
+  getSyncStatus: SyncStatus @shareable
+  getStateByCID(cid: String!): ResultState @shareable
+  getState(blockHash: String!, contractAddress: String!, kind: String): ResultState @shareable
+}
+
+type Mutation {
+  watchContract(address: String!, kind: String!, checkpoint: Boolean!, startingBlock: Int): Boolean! @shareable
+}
+
+type Subscription {
+  onEvent: ResultEvent! @shareable
+}

--- a/packages/censures-watcher/environments/local.toml
+++ b/packages/censures-watcher/environments/local.toml
@@ -1,6 +1,6 @@
 [server]
   host = "127.0.0.1"
-  port = 3009
+  port = 3002
   kind = "lazy"
 
   # Checkpointing state.
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/packages/claims-watcher/environments/local.toml
+++ b/packages/claims-watcher/environments/local.toml
@@ -1,6 +1,6 @@
 [server]
   host = "127.0.0.1"
-  port = 3009
+  port = 3003
   kind = "lazy"
 
   # Checkpointing state.
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/packages/conditional-star-release-watcher/environments/local.toml
+++ b/packages/conditional-star-release-watcher/environments/local.toml
@@ -1,6 +1,6 @@
 [server]
   host = "127.0.0.1"
-  port = 3009
+  port = 3004
   kind = "lazy"
 
   # Checkpointing state.
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/packages/conditional-star-release-watcher/src/schema.gql
+++ b/packages/conditional-star-release-watcher/src/schema.gql
@@ -111,7 +111,10 @@ type ResultState {
 type Query {
   events(blockHash: String!, contractAddress: String!, name: String): [ResultEvent!]
   eventsInRange(fromBlockNumber: Int!, toBlockNumber: Int!): [ResultEvent!]
-  withdrawLimit(blockHash: String!, contractAddress: String!, _participant: String!, _batch: Int!): ResultInt!
+
+  # Set _batch as optional param to merge schema with LinearStarRelease watcher
+  withdrawLimit(blockHash: String!, contractAddress: String!, _participant: String!, _batch: Int): ResultInt!
+
   verifyBalance(blockHash: String!, contractAddress: String!, _participant: String!): ResultBoolean!
   getBatches(blockHash: String!, contractAddress: String!, _participant: String!): ResultIntArray!
   getBatch(blockHash: String!, contractAddress: String!, _participant: String!, _batch: Int!): ResultInt!

--- a/packages/delegated-sending-watcher/environments/local.toml
+++ b/packages/delegated-sending-watcher/environments/local.toml
@@ -1,6 +1,6 @@
 [server]
   host = "127.0.0.1"
-  port = 3009
+  port = 3005
   kind = "lazy"
 
   # Checkpointing state.
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/packages/ecliptic-watcher/environments/local.toml
+++ b/packages/ecliptic-watcher/environments/local.toml
@@ -1,6 +1,6 @@
 [server]
   host = "127.0.0.1"
-  port = 3009
+  port = 3006
   kind = "lazy"
 
   # Checkpointing state.
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/packages/linear-star-release-watcher/environments/local.toml
+++ b/packages/linear-star-release-watcher/environments/local.toml
@@ -1,6 +1,6 @@
 [server]
   host = "127.0.0.1"
-  port = 3009
+  port = 3007
   kind = "lazy"
 
   # Checkpointing state.
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/packages/polls-watcher/environments/local.toml
+++ b/packages/polls-watcher/environments/local.toml
@@ -30,11 +30,11 @@
     # GQL cache-control max-age settings (in seconds)
     maxAge = 15
 
-[metrics]
-  host = "127.0.0.1"
-  port = 9000
-  [metrics.gql]
-    port = 9001
+# [metrics]
+#   host = "127.0.0.1"
+#   port = 9000
+#   [metrics.gql]
+#     port = 9001
 
 [database]
   type = "postgres"
@@ -48,8 +48,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    rpcProviderEndpoint = "http://127.0.0.1:8081"
+    gqlApiEndpoint = "http://127.0.0.1:8083/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8082"
 
   [upstream.cache]
     name = "requests"

--- a/router.yaml
+++ b/router.yaml
@@ -1,0 +1,10 @@
+sandbox:
+  enabled: true
+
+# Sandbox uses introspection to obtain your router's schema.
+supergraph:
+  introspection: true
+
+# Sandbox requires the default landing page to be disabled.
+homepage:
+  enabled: false

--- a/supergraph-config.yaml
+++ b/supergraph-config.yaml
@@ -1,0 +1,34 @@
+federation_version: 2
+subgraphs:
+  azimuth:
+    routing_url: http://localhost:3001/graphql
+    schema:
+      file: ./packages/azimuth-watcher/src/subgraph-schema.gql
+  censures:
+    routing_url: http://localhost:3002/graphql
+    schema:
+      file: ./packages/censures-watcher/src/schema.gql
+  claims:
+    routing_url: http://localhost:3003/graphql
+    schema:
+      file: ./packages/claims-watcher/src/schema.gql
+  conditional_star_release:
+    routing_url: http://localhost:3004/graphql
+    schema:
+      file: ./packages/conditional-star-release-watcher/src/schema.gql
+  delegated_sending:
+    routing_url: http://localhost:3005/graphql
+    schema:
+      file: ./packages/delegated-sending-watcher/src/schema.gql
+  ecliptic:
+    routing_url: http://localhost:3006/graphql
+    schema:
+      file: ./packages/ecliptic-watcher/src/schema.gql
+  linear_star_release:
+    routing_url: http://localhost:3007/graphql
+    schema:
+      file: ./packages/linear-star-release-watcher/src/schema.gql
+  polls:
+    routing_url: http://localhost:3008/graphql
+    schema:
+      file: ./packages/polls-watcher/src/schema.gql

--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -1,0 +1,699 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+{
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type _Block_
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  cid: String!
+  hash: String!
+  number: Int!
+  timestamp: Int!
+  parentHash: String!
+}
+
+type _Transaction_
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  hash: String!
+  index: Int!
+  from: String!
+  to: String!
+}
+
+type ActivatedEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+}
+
+type ApprovalEvent
+  @join__type(graph: ECLIPTIC)
+{
+  _owner: String!
+  _approved: String!
+  _tokenId: BigInt!
+}
+
+type ApprovalForAllEvent
+  @join__type(graph: ECLIPTIC)
+{
+  _owner: String!
+  _operator: String!
+  _approved: Boolean!
+}
+
+scalar BigDecimal
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+
+scalar BigInt
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+
+type BrokeContinuityEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  number: BigInt!
+}
+
+scalar Bytes
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+
+enum CacheControlScope
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  PUBLIC @join__enumValue(graph: AZIMUTH) @join__enumValue(graph: CENSURES) @join__enumValue(graph: CLAIMS) @join__enumValue(graph: CONDITIONAL_STAR_RELEASE) @join__enumValue(graph: DELEGATED_SENDING) @join__enumValue(graph: ECLIPTIC) @join__enumValue(graph: LINEAR_STAR_RELEASE) @join__enumValue(graph: POLLS)
+  PRIVATE @join__enumValue(graph: AZIMUTH) @join__enumValue(graph: CENSURES) @join__enumValue(graph: CLAIMS) @join__enumValue(graph: CONDITIONAL_STAR_RELEASE) @join__enumValue(graph: DELEGATED_SENDING) @join__enumValue(graph: ECLIPTIC) @join__enumValue(graph: LINEAR_STAR_RELEASE) @join__enumValue(graph: POLLS)
+}
+
+type CensuredEvent
+  @join__type(graph: CENSURES)
+{
+  by: Int!
+  who: BigInt!
+}
+
+type ChangedDnsEvent
+  @join__type(graph: AZIMUTH)
+{
+  primary: String!
+  secondary: String!
+  tertiary: String!
+}
+
+type ChangedKeysEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  encryptionKey: String!
+  authenticationKey: String!
+  cryptoSuiteVersion: BigInt!
+  keyRevisionNumber: BigInt!
+}
+
+type ChangedManagementProxyEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  managementProxy: String!
+}
+
+type ChangedSpawnProxyEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  spawnProxy: String!
+}
+
+type ChangedTransferProxyEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  transferProxy: String!
+}
+
+type ChangedVotingProxyEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  votingProxy: String!
+}
+
+type ClaimAddedEvent
+  @join__type(graph: CLAIMS)
+{
+  by: BigInt!
+  _protocol: String!
+  _claim: String!
+  _dossier: String!
+}
+
+type ClaimRemovedEvent
+  @join__type(graph: CLAIMS)
+{
+  by: BigInt!
+  _protocol: String!
+  _claim: String!
+}
+
+type ConditionCompletedEvent
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+{
+  condition: Int!
+  when: BigInt!
+}
+
+type DocumentMajorityEvent
+  @join__type(graph: POLLS)
+{
+  proposal: String!
+}
+
+type DocumentPollStartedEvent
+  @join__type(graph: POLLS)
+{
+  proposal: String!
+}
+
+type EscapeAcceptedEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+type EscapeCanceledEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+type EscapeRequestedEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+union Event
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+  @join__unionMember(graph: AZIMUTH, member: "OwnerChangedEvent")
+  @join__unionMember(graph: AZIMUTH, member: "ActivatedEvent")
+  @join__unionMember(graph: AZIMUTH, member: "SpawnedEvent")
+  @join__unionMember(graph: AZIMUTH, member: "EscapeRequestedEvent")
+  @join__unionMember(graph: AZIMUTH, member: "EscapeCanceledEvent")
+  @join__unionMember(graph: AZIMUTH, member: "EscapeAcceptedEvent")
+  @join__unionMember(graph: AZIMUTH, member: "LostSponsorEvent")
+  @join__unionMember(graph: AZIMUTH, member: "ChangedKeysEvent")
+  @join__unionMember(graph: AZIMUTH, member: "BrokeContinuityEvent")
+  @join__unionMember(graph: AZIMUTH, member: "ChangedSpawnProxyEvent")
+  @join__unionMember(graph: AZIMUTH, member: "ChangedTransferProxyEvent")
+  @join__unionMember(graph: AZIMUTH, member: "ChangedManagementProxyEvent")
+  @join__unionMember(graph: AZIMUTH, member: "ChangedVotingProxyEvent")
+  @join__unionMember(graph: AZIMUTH, member: "ChangedDnsEvent")
+  @join__unionMember(graph: AZIMUTH, member: "OwnershipRenouncedEvent")
+  @join__unionMember(graph: CONDITIONAL_STAR_RELEASE, member: "OwnershipRenouncedEvent")
+  @join__unionMember(graph: ECLIPTIC, member: "OwnershipRenouncedEvent")
+  @join__unionMember(graph: LINEAR_STAR_RELEASE, member: "OwnershipRenouncedEvent")
+  @join__unionMember(graph: POLLS, member: "OwnershipRenouncedEvent")
+  @join__unionMember(graph: AZIMUTH, member: "OwnershipTransferredEvent")
+  @join__unionMember(graph: CONDITIONAL_STAR_RELEASE, member: "OwnershipTransferredEvent")
+  @join__unionMember(graph: ECLIPTIC, member: "OwnershipTransferredEvent")
+  @join__unionMember(graph: LINEAR_STAR_RELEASE, member: "OwnershipTransferredEvent")
+  @join__unionMember(graph: POLLS, member: "OwnershipTransferredEvent")
+  @join__unionMember(graph: CENSURES, member: "CensuredEvent")
+  @join__unionMember(graph: CENSURES, member: "ForgivenEvent")
+  @join__unionMember(graph: CLAIMS, member: "ClaimAddedEvent")
+  @join__unionMember(graph: CLAIMS, member: "ClaimRemovedEvent")
+  @join__unionMember(graph: CONDITIONAL_STAR_RELEASE, member: "ConditionCompletedEvent")
+  @join__unionMember(graph: CONDITIONAL_STAR_RELEASE, member: "ForfeitEvent")
+  @join__unionMember(graph: DELEGATED_SENDING, member: "SentEvent")
+  @join__unionMember(graph: ECLIPTIC, member: "TransferEvent")
+  @join__unionMember(graph: ECLIPTIC, member: "ApprovalEvent")
+  @join__unionMember(graph: ECLIPTIC, member: "ApprovalForAllEvent")
+  @join__unionMember(graph: ECLIPTIC, member: "UpgradedEvent")
+  @join__unionMember(graph: POLLS, member: "UpgradePollStartedEvent")
+  @join__unionMember(graph: POLLS, member: "DocumentPollStartedEvent")
+  @join__unionMember(graph: POLLS, member: "UpgradeMajorityEvent")
+  @join__unionMember(graph: POLLS, member: "DocumentMajorityEvent")
+ = OwnerChangedEvent | ActivatedEvent | SpawnedEvent | EscapeRequestedEvent | EscapeCanceledEvent | EscapeAcceptedEvent | LostSponsorEvent | ChangedKeysEvent | BrokeContinuityEvent | ChangedSpawnProxyEvent | ChangedTransferProxyEvent | ChangedManagementProxyEvent | ChangedVotingProxyEvent | ChangedDnsEvent | OwnershipRenouncedEvent | OwnershipTransferredEvent | CensuredEvent | ForgivenEvent | ClaimAddedEvent | ClaimRemovedEvent | ConditionCompletedEvent | ForfeitEvent | SentEvent | TransferEvent | ApprovalEvent | ApprovalForAllEvent | UpgradedEvent | UpgradePollStartedEvent | DocumentPollStartedEvent | UpgradeMajorityEvent | DocumentMajorityEvent
+
+type ForfeitEvent
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+{
+  who: String!
+  batch: Int!
+  stars: Int!
+}
+
+type ForgivenEvent
+  @join__type(graph: CENSURES)
+{
+  by: Int!
+  who: BigInt!
+}
+
+type GetConditionsStateType
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+{
+  value0: [String!]!
+  value1: [BigInt!]!
+  value2: [BigInt!]!
+  value3: [BigInt!]!
+}
+
+type GetKeysType
+  @join__type(graph: AZIMUTH)
+{
+  value0: String!
+  value1: String!
+  value2: BigInt!
+  value3: BigInt!
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  AZIMUTH @join__graph(name: "azimuth", url: "http://localhost:3001/graphql")
+  CENSURES @join__graph(name: "censures", url: "http://localhost:3002/graphql")
+  CLAIMS @join__graph(name: "claims", url: "http://localhost:3003/graphql")
+  CONDITIONAL_STAR_RELEASE @join__graph(name: "conditional_star_release", url: "http://localhost:3004/graphql")
+  DELEGATED_SENDING @join__graph(name: "delegated_sending", url: "http://localhost:3005/graphql")
+  ECLIPTIC @join__graph(name: "ecliptic", url: "http://localhost:3006/graphql")
+  LINEAR_STAR_RELEASE @join__graph(name: "linear_star_release", url: "http://localhost:3007/graphql")
+  POLLS @join__graph(name: "polls", url: "http://localhost:3008/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type LostSponsorEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  sponsor: BigInt!
+}
+
+type Mutation
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  watchContract(address: String!, kind: String!, checkpoint: Boolean!, startingBlock: Int): Boolean!
+}
+
+type OwnerChangedEvent
+  @join__type(graph: AZIMUTH)
+{
+  point: BigInt!
+  owner: String!
+}
+
+type OwnershipRenouncedEvent
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  previousOwner: String!
+}
+
+type OwnershipTransferredEvent
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  previousOwner: String!
+  newOwner: String!
+}
+
+type Proof
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  data: String!
+}
+
+type Query
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  events(blockHash: String!, contractAddress: String!, name: String): [ResultEvent!]
+  eventsInRange(fromBlockNumber: Int!, toBlockNumber: Int!): [ResultEvent!]
+  isActive(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getKeys(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultGetKeysType! @join__field(graph: AZIMUTH)
+  getKeyRevisionNumber(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  hasBeenLinked(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean! @join__field(graph: AZIMUTH)
+  isLive(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getContinuityNumber(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getSpawnCount(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getSpawned(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  hasSponsor(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getSponsor(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  isSponsor(blockHash: String!, contractAddress: String!, _point: BigInt!, _sponsor: BigInt!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getSponsoringCount(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getSponsoring(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  isEscaping(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getEscapeRequest(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  isRequestingEscapeTo(blockHash: String!, contractAddress: String!, _point: BigInt!, _sponsor: BigInt!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getEscapeRequestsCount(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getEscapeRequests(blockHash: String!, contractAddress: String!, _sponsor: BigInt!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  getOwner(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString! @join__field(graph: AZIMUTH)
+  isOwner(blockHash: String!, contractAddress: String!, _point: BigInt!, _address: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getOwnedPointCount(blockHash: String!, contractAddress: String!, _whose: String!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getOwnedPoints(blockHash: String!, contractAddress: String!, _whose: String!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  getOwnedPointAtIndex(blockHash: String!, contractAddress: String!, _whose: String!, _index: BigInt!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getManagementProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString! @join__field(graph: AZIMUTH)
+  isManagementProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  canManage(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getManagerForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getManagerFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  getSpawnProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString! @join__field(graph: AZIMUTH)
+  isSpawnProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  canSpawnAs(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getSpawningForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getSpawningFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  getVotingProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString! @join__field(graph: AZIMUTH)
+  isVotingProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  canVoteAs(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getVotingForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getVotingFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  getTransferProxy(blockHash: String!, contractAddress: String!, _point: BigInt!): ResultString! @join__field(graph: AZIMUTH)
+  isTransferProxy(blockHash: String!, contractAddress: String!, _point: BigInt!, _proxy: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  canTransfer(blockHash: String!, contractAddress: String!, _point: BigInt!, _who: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getTransferringForCount(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigInt! @join__field(graph: AZIMUTH)
+  getTransferringFor(blockHash: String!, contractAddress: String!, _proxy: String!): ResultBigIntArray! @join__field(graph: AZIMUTH)
+  isOperator(blockHash: String!, contractAddress: String!, _owner: String!, _operator: String!): ResultBoolean! @join__field(graph: AZIMUTH)
+  getSyncStatus: SyncStatus
+  getStateByCID(cid: String!): ResultState
+  getState(blockHash: String!, contractAddress: String!, kind: String): ResultState
+  getCensuringCount(blockHash: String!, contractAddress: String!, _whose: Int!): ResultBigInt! @join__field(graph: CENSURES)
+  getCensuring(blockHash: String!, contractAddress: String!, _whose: Int!): ResultBigIntArray! @join__field(graph: CENSURES)
+  getCensuredByCount(blockHash: String!, contractAddress: String!, _who: Int!): ResultBigInt! @join__field(graph: CENSURES)
+  getCensuredBy(blockHash: String!, contractAddress: String!, _who: Int!): ResultIntArray! @join__field(graph: CENSURES)
+  findClaim(blockHash: String!, contractAddress: String!, _whose: BigInt!, _protocol: String!, _claim: String!): ResultInt! @join__field(graph: CLAIMS)
+  withdrawLimit(blockHash: String!, contractAddress: String!, _participant: String!): ResultInt! @join__field(graph: CONDITIONAL_STAR_RELEASE) @join__field(graph: LINEAR_STAR_RELEASE)
+  verifyBalance(blockHash: String!, contractAddress: String!, _participant: String!): ResultBoolean! @join__field(graph: CONDITIONAL_STAR_RELEASE) @join__field(graph: LINEAR_STAR_RELEASE)
+  getBatches(blockHash: String!, contractAddress: String!, _participant: String!): ResultIntArray! @join__field(graph: CONDITIONAL_STAR_RELEASE)
+  getBatch(blockHash: String!, contractAddress: String!, _participant: String!, _batch: Int!): ResultInt! @join__field(graph: CONDITIONAL_STAR_RELEASE)
+  getWithdrawn(blockHash: String!, contractAddress: String!, _participant: String!): ResultIntArray! @join__field(graph: CONDITIONAL_STAR_RELEASE)
+  getWithdrawnFromBatch(blockHash: String!, contractAddress: String!, _participant: String!, _batch: Int!): ResultInt! @join__field(graph: CONDITIONAL_STAR_RELEASE)
+  getForfeited(blockHash: String!, contractAddress: String!, _participant: String!): ResultBooleanArray! @join__field(graph: CONDITIONAL_STAR_RELEASE)
+  hasForfeitedBatch(blockHash: String!, contractAddress: String!, _participant: String!, _batch: Int!): ResultBoolean! @join__field(graph: CONDITIONAL_STAR_RELEASE)
+  getRemainingStars(blockHash: String!, contractAddress: String!, _participant: String!): ResultIntArray! @join__field(graph: CONDITIONAL_STAR_RELEASE) @join__field(graph: LINEAR_STAR_RELEASE)
+  getConditionsState(blockHash: String!, contractAddress: String!): ResultGetConditionsStateType! @join__field(graph: CONDITIONAL_STAR_RELEASE)
+  canSend(blockHash: String!, contractAddress: String!, _as: BigInt!, _point: BigInt!): ResultBoolean! @join__field(graph: DELEGATED_SENDING)
+  canReceive(blockHash: String!, contractAddress: String!, _recipient: String!): ResultBoolean! @join__field(graph: DELEGATED_SENDING)
+  supportsInterface(blockHash: String!, contractAddress: String!, _interfaceId: String!): ResultBoolean! @join__field(graph: ECLIPTIC)
+  name(blockHash: String!, contractAddress: String!): ResultString! @join__field(graph: ECLIPTIC)
+  symbol(blockHash: String!, contractAddress: String!): ResultString! @join__field(graph: ECLIPTIC)
+  tokenURI(blockHash: String!, contractAddress: String!, _tokenId: BigInt!): ResultString! @join__field(graph: ECLIPTIC)
+  balanceOf(blockHash: String!, contractAddress: String!, _owner: String!): ResultBigInt! @join__field(graph: ECLIPTIC)
+  ownerOf(blockHash: String!, contractAddress: String!, _tokenId: BigInt!): ResultString! @join__field(graph: ECLIPTIC)
+  exists(blockHash: String!, contractAddress: String!, _tokenId: BigInt!): ResultBoolean! @join__field(graph: ECLIPTIC)
+  getApproved(blockHash: String!, contractAddress: String!, _tokenId: BigInt!): ResultString! @join__field(graph: ECLIPTIC)
+  isApprovedForAll(blockHash: String!, contractAddress: String!, _owner: String!, _operator: String!): ResultBoolean! @join__field(graph: ECLIPTIC)
+  getSpawnLimit(blockHash: String!, contractAddress: String!, _point: BigInt!, _time: BigInt!): ResultBigInt! @join__field(graph: ECLIPTIC)
+  canEscapeTo(blockHash: String!, contractAddress: String!, _point: BigInt!, _sponsor: BigInt!): ResultBoolean! @join__field(graph: ECLIPTIC)
+  getUpgradeProposals(blockHash: String!, contractAddress: String!): ResultStringArray! @join__field(graph: POLLS)
+  getUpgradeProposalCount(blockHash: String!, contractAddress: String!): ResultBigInt! @join__field(graph: POLLS)
+  getDocumentProposals(blockHash: String!, contractAddress: String!): ResultStringArray! @join__field(graph: POLLS)
+  getDocumentProposalCount(blockHash: String!, contractAddress: String!): ResultBigInt! @join__field(graph: POLLS)
+  getDocumentMajorities(blockHash: String!, contractAddress: String!): ResultStringArray! @join__field(graph: POLLS)
+  hasVotedOnUpgradePoll(blockHash: String!, contractAddress: String!, _galaxy: Int!, _proposal: String!): ResultBoolean! @join__field(graph: POLLS)
+  hasVotedOnDocumentPoll(blockHash: String!, contractAddress: String!, _galaxy: Int!, _proposal: String!): ResultBoolean! @join__field(graph: POLLS)
+}
+
+type ResultBigInt
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: POLLS)
+{
+  value: BigInt!
+  proof: Proof
+}
+
+type ResultBigIntArray
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+{
+  value: [BigInt!]!
+  proof: Proof
+}
+
+type ResultBoolean
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  value: Boolean!
+  proof: Proof
+}
+
+type ResultBooleanArray
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+{
+  value: [Boolean!]!
+  proof: Proof
+}
+
+type ResultEvent
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  block: _Block_!
+  tx: _Transaction_!
+  contract: String!
+  eventIndex: Int!
+  event: Event! @inaccessible
+  proof: Proof
+}
+
+type ResultGetConditionsStateType
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+{
+  value: GetConditionsStateType!
+  proof: Proof
+}
+
+type ResultGetKeysType
+  @join__type(graph: AZIMUTH)
+{
+  value: GetKeysType!
+  proof: Proof
+}
+
+type ResultInt
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+{
+  value: Int!
+  proof: Proof
+}
+
+type ResultIntArray
+  @join__type(graph: CENSURES)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+{
+  value: [Int!]!
+  proof: Proof
+}
+
+type ResultState
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  block: _Block_!
+  contractAddress: String!
+  cid: String!
+  kind: String!
+  data: String!
+}
+
+type ResultString
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: ECLIPTIC)
+{
+  value: String!
+  proof: Proof
+}
+
+type ResultStringArray
+  @join__type(graph: POLLS)
+{
+  value: [String!]!
+  proof: Proof
+}
+
+type SentEvent
+  @join__type(graph: DELEGATED_SENDING)
+{
+  prefix: Int!
+  fromPool: BigInt!
+  by: BigInt!
+  point: BigInt!
+  to: String!
+}
+
+type SpawnedEvent
+  @join__type(graph: AZIMUTH)
+{
+  prefix: BigInt!
+  child: BigInt!
+}
+
+type Subscription
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  onEvent: ResultEvent!
+}
+
+type SyncStatus
+  @join__type(graph: AZIMUTH)
+  @join__type(graph: CENSURES)
+  @join__type(graph: CLAIMS)
+  @join__type(graph: CONDITIONAL_STAR_RELEASE)
+  @join__type(graph: DELEGATED_SENDING)
+  @join__type(graph: ECLIPTIC)
+  @join__type(graph: LINEAR_STAR_RELEASE)
+  @join__type(graph: POLLS)
+{
+  latestIndexedBlockHash: String!
+  latestIndexedBlockNumber: Int!
+  latestCanonicalBlockHash: String!
+  latestCanonicalBlockNumber: Int!
+}
+
+type TransferEvent
+  @join__type(graph: ECLIPTIC)
+{
+  _from: String!
+  _to: String!
+  _tokenId: BigInt!
+}
+
+type UpgradedEvent
+  @join__type(graph: ECLIPTIC)
+{
+  to: String!
+}
+
+type UpgradeMajorityEvent
+  @join__type(graph: POLLS)
+{
+  proposal: String!
+}
+
+type UpgradePollStartedEvent
+  @join__type(graph: POLLS)
+{
+  proposal: String!
+}


### PR DESCRIPTION
Part of cerc-io/watcher-ts#351

- Use Apollo router to proxy GQL queries

TODO:
- Fix common `withdrawLimit` query in `ConditionalStarRelease` and `LinearStarRelease` watchers
- Setup docker with all watchers and router to proxy GQL queries 